### PR TITLE
Fix for odd `screen.availWidth`

### DIFF
--- a/Chrome/stackexchange-inbox-api-chrome.js
+++ b/Chrome/stackexchange-inbox-api-chrome.js
@@ -5,7 +5,7 @@ StackExchangeInbox.auth.requestToken = function() {
         focused: true,
         type: 'popup',
         top: 0,
-        left: Math.max(0, (screen.availWidth - 660) / 2),
+        left: Math.max(0, Math.round((screen.availWidth - 660) / 2)),
         height: Math.min(screen.availHeight, 480),
         width: Math.min(screen.availWidth, 660)
     });


### PR DESCRIPTION
Chrome calculates screen dimensions taking into account system toolbars; as a result, on my Ubuntu system with a side Unity taskbar `screen.availWidth == 1855` and the token request code fails, as Chrome expects an integer.
