### PR TITLE
Fix initial link setting

### DIFF
--- a/Chrome/options.js
+++ b/Chrome/options.js
@@ -13,7 +13,7 @@ var socketStop = document.getElementById('socket-stop');
 var autostart = document.getElementById('autostart');
 
 uid.defaultValue = uid.value = bg.getUserID() || '';
-link.defaultValue = link.value = bg.getLink();
+link.defaultValue = link.value = bg.getLink() || '';
 link.placeholder = bg.generateDefaultLink('<uid>');
 link.title += ' Defaults to ' + bg.generateDefaultLink('<uid>');
 


### PR DESCRIPTION
Without this fix, on extension initialization:

`localStorage['open-on-click'] === undefined`
`localStorage.getItem('open-on-click') === null`

JavaScript, in its infinite wisdom, assigns a _string_ "null" here:
`link.defaultValue = link.value = bg.getLink();`

Therefore, upon opening the options page the link field is filled with "null", and if options are saved the default link is prevented from being used.
