### PR TITLE
Add optional notification persistence (Chrome 50+)

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -3,6 +3,7 @@
     "description": "Real-time desktop notifications for the Stack Exchange.",
     "version": "1.6.10",
     "manifest_version": 2,
+    "minimum_chrome_version": "50",
     "background": {
         "scripts": [
             "localStorage-proxy.js",

--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -3,7 +3,6 @@
     "description": "Real-time desktop notifications for the Stack Exchange.",
     "version": "1.6.10",
     "manifest_version": 2,
-    "minimum_chrome_version": "50",
     "background": {
         "scripts": [
             "localStorage-proxy.js",

--- a/Chrome/options-chromeonly.js
+++ b/Chrome/options-chromeonly.js
@@ -4,6 +4,7 @@ var bg = chrome.extension.getBackgroundPage();
 var incognito = document.getElementById('incognito');
 var autostart = document.getElementById('autostart');
 var run_in_bg = document.getElementById('run_in_bg');
+var persist_notification = document.getElementById('persist_notification');
 
 document.getElementById('default-link').textContent = bg.generateDefaultLink('<uid>');
 
@@ -33,6 +34,13 @@ run_in_bg.onchange = function() {
         chrome.permissions.remove(_chromePermissions, function(result) { setPermissionCheckbox(!result); });
     }
 };
+
+// Persist Chrome notifications?
+persist_notification.checked = !!localStorage.getItem('persist_notification');
+persist_notification.onchange = function() {
+    localStorage.setItem('persist_notification', this.checked ? '1' : '');
+};
+
 // Currently, there's only one optional permission. Don't check whether the added/removed permission is "background"
 chrome.permissions.onRemoved.addListener(function(permissions) {
     setPermissionCheckbox(false);

--- a/Chrome/options.html
+++ b/Chrome/options.html
@@ -30,7 +30,7 @@
     <label><input type="checkbox" id="autostart" tabindex="5"> Automatically start socket connection.</label><br>
     <label><input type="checkbox" id="run_in_bg" tabindex="6"> Run extension even if all Chrome tabs are closed.</label><br>
     <label><input type="checkbox" id="incognito" tabindex="7"> Open tabs in incognito mode.</label><br>
-    <label><input type="checkbox" id="persist_notification" tabindex="7"> Persistent notifications.</label><br>
+    <label><input type="checkbox" id="persist_notification" tabindex="7"> Persistent notifications (Chrome 50+).</label><br>
 </div>
 <div class="container">
     Socket status: <span id="status"></span>.<br>

--- a/Chrome/options.html
+++ b/Chrome/options.html
@@ -30,6 +30,7 @@
     <label><input type="checkbox" id="autostart" tabindex="5"> Automatically start socket connection.</label><br>
     <label><input type="checkbox" id="run_in_bg" tabindex="6"> Run extension even if all Chrome tabs are closed.</label><br>
     <label><input type="checkbox" id="incognito" tabindex="7"> Open tabs in incognito mode.</label><br>
+    <label><input type="checkbox" id="persist_notification" tabindex="7"> Persistent notifications.</label><br>
 </div>
 <div class="container">
     Socket status: <span id="status"></span>.<br>

--- a/Chrome/using-websocket.js
+++ b/Chrome/using-websocket.js
@@ -240,6 +240,7 @@ if (chrome.notifications) {
 }
 function showNotification() {
     var notID = _currentNotificationID = new Date().getTime();
+    var persistNotification = !!localStorage.getItem('persist_notification');
     if (_notification) _notification.cancel();
     else if (chrome.notifications) chrome.notifications.clear(CHROME_NOTIFICATION_ID, function() {});
     if (getUnreadCount() > 0) {
@@ -251,7 +252,8 @@ function showNotification() {
                 type: 'basic',
                 iconUrl: iconURL,
                 title: head,
-                message: body
+                message: body,
+                requireInteraction: persistNotification,
             };
             if (chromeNotificationSupportsClick) {
                 notificationOptions.isClickable = true;


### PR DESCRIPTION
Backwards-compatible (though will still show as an option), defaults to false.